### PR TITLE
Fix CPU

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -817,7 +817,7 @@ static void export_kernel_boot_props() {
         { "ro.boot.mode",       "ro.bootmode",   "unknown", },
         { "ro.boot.baseband",   "ro.baseband",   "unknown", },
         { "ro.boot.bootloader", "ro.bootloader", "unknown", },
-        { "ro.boot.hardware",   "ro.hardware",   "mt6592", },
+        { "ro.boot.hardware",   "ro.hardware",   "mt6572", },
 #ifndef IGNORE_RO_BOOT_REVISION
         { "ro.boot.revision",   "ro.revision",   "0", },
 #endif


### PR DESCRIPTION
Now you can remove the fstab.mt6592